### PR TITLE
naiveproxy: add mirrors for profdata to workaround the build issue

### DIFF
--- a/naiveproxy/Makefile
+++ b/naiveproxy/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=naiveproxy
 PKG_VERSION:=96.0.4664.45-1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/klzgrad/naiveproxy/tar.gz/v$(PKG_VERSION)?
@@ -88,7 +88,9 @@ PGO_VER:=4664-1636557077-6e390f4e505916531ca2ab0c895d5903ab4d88a9
 PGO_FILE:=chrome-linux-$(PGO_VER).profdata
 define Download/PGO_PROF
 	URL:=https://storage.googleapis.com.cnpmjs.org/chromium-optimization-profiles/pgo_profiles \
-	     https://storage.googleapis.com/chromium-optimization-profiles/pgo_profiles
+	     https://storage.googleapis.com/chromium-optimization-profiles/pgo_profiles \
+	     https://mirror01.download.immortalwrt.eu.org \
+	     https://mirror02.download.immortalwrt.eu.org
 	URL_FILE:=$(PGO_FILE)
 	FILE:=$(PGO_FILE)
 	HASH:=8dcf5973033d40c9a7b15e571dea3832e7b67976aad9113369e22d43808c603f


### PR DESCRIPTION
profdata was modified by upstream, and the new one seems to break the
build. I have no idea why.

Fixes: #721

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>